### PR TITLE
Fix crash using Compress(Stream,Stream)

### DIFF
--- a/WinBrotli/Brotli/BrotliCompression.cs
+++ b/WinBrotli/Brotli/BrotliCompression.cs
@@ -37,7 +37,7 @@ namespace Brotli
 
         public static void Compress(Stream input, Stream output)
         {
-            Compress(CreateDefaultParameters(), input, input);
+            Compress(CreateDefaultParameters(), input, output);
         }
 
         public static void Compress(CompressionParameters parameters, Stream input, Stream output)


### PR DESCRIPTION
Hello,

Firstly, thanks for creating this project.

Secondly, this PR is for a minor issue I spotted whilst testing your `BrotliCompression` class. The `Compress(Stream input, Stream output)` overload is ignoring the `output` argument and instead passing `input` twice, causing an empty `BrotliException` to be thrown.

Regards;
Richard Moss
